### PR TITLE
revert windows driver attempt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 env:
   PROJECT_NAME: qdl
   REPO_NAME: linux-msm/qdl
-  REPO_REF: cd3272350328185b1d4f7de08fdecf38f8fd31be
+  REPO_REF: 672abb1e81cc630640f2a88e42b6dfd2a429ad14
   DIST_DIR: dist
   ARTIFACT_NAME: dist
 

--- a/patches/build_static.patch
+++ b/patches/build_static.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index ddd06c9..bef69c4 100644
+index 203cb04..4482eb8 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -3,7 +3,7 @@ RAMDUMP := qdl-ramdump
@@ -8,6 +8,6 @@ index ddd06c9..bef69c4 100644
  CFLAGS += -O2 -Wall -g `pkg-config --cflags libxml-2.0 libusb-1.0`
 -LDFLAGS += `pkg-config --libs libxml-2.0 libusb-1.0`
 +LDFLAGS += `pkg-config --libs libxml-2.0 libusb-1.0 --static`
- ifeq ($(OS),Windows_NT)
- LDFLAGS += -lws2_32
- endif
+ prefix := /usr/local
+ 
+ QDL_SRCS := firehose.c io.c qdl.c sahara.c util.c patch.c program.c read.c sim.c ufs.c usb.c ux.c oscompat.c


### PR DESCRIPTION
The attempt to update qdl to improve Windows support didn't work; the old packaged version was enough, so we just reverted those changes to a more stable situation.

closes https://github.com/arduino/qdl-packing/issues/3