### PR TITLE
feat: add macos arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,12 @@ name: release
 env:
   PROJECT_NAME: qdl
   REPO_NAME: linux-msm/qdl
-  REPO_REF: a601db1868bcda454a77b6769ca9efac3b0a114c
+  REPO_REF: v2.2
   DIST_DIR: dist
   ARTIFACT_NAME: dist
 
 on:
-  push:
-    tags:
-      - '*'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -71,7 +69,7 @@ jobs:
     - name: Package
       working-directory: ${{ env.PROJECT_NAME }}
       run: | 
-        tar -czvf ../${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz \
+        tar -czvf ../${{ env.PROJECT_NAME }}_${{ env.REPO_REF }}-${{ github.run_number }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz \
                   qdl${{ matrix.config.extension }}
 
     - name: Upload artifacts
@@ -79,7 +77,7 @@ jobs:
       with:
         if-no-files-found: error
         name: ${{ env.ARTIFACT_NAME }}_${{ matrix.config.os }}_${{ matrix.config.arch }}
-        path: ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
+        path: ${{ env.PROJECT_NAME }}_${{ env.REPO_REF }}-${{ github.run_number }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
 
   build-macos-arm64:
     name: build
@@ -134,14 +132,14 @@ jobs:
     - name: Package
       working-directory: ${{ env.PROJECT_NAME }}
       run: | 
-        tar -czvf ../${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz qdl
+        tar -czvf ../${{ env.PROJECT_NAME }}_${{ env.REPO_REF }}-${{ github.run_number }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz qdl
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
         name: ${{ env.ARTIFACT_NAME }}_${{ matrix.config.os }}_${{ matrix.config.arch }}
-        path: ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
+        path: ${{ env.PROJECT_NAME }}_${{ env.REPO_REF }}-${{ github.run_number }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
 
   sign-and-notarize-macos:
     name: sign and notarize
@@ -172,7 +170,7 @@ jobs:
 
       - name: Extract macOS binary
         working-directory: ${{ env.DIST_DIR }}/notarize_temp
-        run: tar -xzvf ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
+        run: tar -xzvf ${{ env.PROJECT_NAME }}_${{ env.REPO_REF }}-${{ github.run_number }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
 
       - name: Import Code-Signing Certificates
         env:
@@ -216,15 +214,15 @@ jobs:
         working-directory: ${{ env.DIST_DIR }}/notarize_temp
         run: |
           chmod +x qdl
-          tar -czvf ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz qdl
-          mv ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz ../
+          tar -czvf ${{ env.PROJECT_NAME }}_${{ env.REPO_REF }}-${{ github.run_number }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz qdl
+          mv ${{ env.PROJECT_NAME }}_${{ env.REPO_REF }}-${{ github.run_number }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz ../
 
       - name: Upload notarized macOS artifact
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: ${{ env.ARTIFACT_NAME }}_${{ matrix.config.os }}_${{ matrix.config.arch }}
-          path: ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
+          path: ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_${{ env.REPO_REF }}-${{ github.run_number }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
           overwrite: true # Important: replace the original macOS artifact
 
   create-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ env:
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - '*'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
             arch: arm64
     runs-on: macos-latest
     env:
-      CROSSBUILD_REF: support-macos-arm64
+      CROSSBUILD_REF: main
     steps:
     - name: Install dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,10 @@ jobs:
     env:
       CROSSBUILD_REF: support-macos-arm64
     steps:
+    - name: Install dependencies
+      run: |
+        brew install pkg-config autoconf automake libtool
+
     - name: Checkout repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
         path: ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
 
   sign-and-notarize-macos:
-    name: sign and notarize (macOS, 64bit)
+    name: sign and notarize macOS binaries
     runs-on: macos-latest 
     needs: [build, build-macos-arm64]
     strategy:
@@ -172,7 +172,7 @@ jobs:
 
       - name: Extract macOS binary
         working-directory: ${{ env.DIST_DIR }}/notarize_temp
-        run: tar -xzvf ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_macOS_64bit.tar.gz
+        run: tar -xzvf ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
 
       - name: Import Code-Signing Certificates
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 env:
   PROJECT_NAME: qdl
   REPO_NAME: linux-msm/qdl
-  REPO_REF: 672abb1e81cc630640f2a88e42b6dfd2a429ad14
+  REPO_REF: a601db1868bcda454a77b6769ca9efac3b0a114c
   DIST_DIR: dist
   ARTIFACT_NAME: dist
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ env:
 on:
   push:
     tags:
-      - '*.*.*'
+      - '*'
 
 jobs:
   build:
-    name: build (${{ matrix.config.os }}, ${{ matrix.config.arch }})
+    name: build
     runs-on:
       ubuntu-latest
     permissions:
@@ -82,7 +82,7 @@ jobs:
         path: ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
 
   build-macos-arm64:
-    name: build macOS arm64 
+    name: build
     permissions:
       contents: read
     strategy:
@@ -144,7 +144,7 @@ jobs:
         path: ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
 
   sign-and-notarize-macos:
-    name: sign and notarize macOS binaries
+    name: sign and notarize
     runs-on: macos-latest 
     needs: [build, build-macos-arm64]
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,10 +81,75 @@ jobs:
         name: ${{ env.ARTIFACT_NAME }}_${{ matrix.config.os }}_${{ matrix.config.arch }}
         path: ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
 
+  build-macos-arm64:
+    name: build macOS arm64 
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        config:
+          - os: macOS
+            arch: arm64
+    runs-on: macos-latest
+    env:
+      CROSSBUILD_REF: support-macos-arm64
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        path: packing
+
+    - name: Checkout arduino/crossbuild repository
+      uses: actions/checkout@v4
+      with:
+        repository: arduino/crossbuild 
+        ref: ${{ env.CROSSBUILD_REF }}
+        path: crossbuild
+    - name: build dependencies
+      working-directory: crossbuild
+      run: ./scripts/build_mac.sh
+
+    - name: Checkout linux-msm/qdl repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ env.REPO_NAME }}
+        ref: ${{ env.REPO_REF }}
+        path: ${{ env.PROJECT_NAME }}
+    - name: Apply patches
+      working-directory: ${{ env.PROJECT_NAME }}
+      run: git apply -v ../packing/patches/*.patch
+
+    - name: build qdl
+      working-directory: ${{ env.PROJECT_NAME }}
+      run: make -j 8
+      env:
+        PKG_CONFIG_PATH: ../crossbuild/build/macos/dist/lib/pkgconfig
+        LD_LIBRARY_PATH: ../crossbuild/build/macos/dist/lib
+        C_INCLUDE_PATH: ../crossbuild/build/macos/dist/include  
+
+    - name: Package
+      working-directory: ${{ env.PROJECT_NAME }}
+      run: | 
+        tar -czvf ../${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz qdl
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: ${{ env.ARTIFACT_NAME }}_${{ matrix.config.os }}_${{ matrix.config.arch }}
+        path: ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
+
   sign-and-notarize-macos:
     name: sign and notarize (macOS, 64bit)
     runs-on: macos-latest 
-    needs: build
+    needs: [build, build-macos-arm64]
+    strategy:
+      matrix:
+        config:
+          - os: macOS
+            arch: 64bit
+          - os: macOS
+            arch: arm64
     permissions:
       contents: read
 
@@ -98,7 +163,7 @@ jobs:
       - name: Download macOS artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_NAME }}_macOS_64bit 
+          name: ${{ env.ARTIFACT_NAME }}_${{ matrix.config.os }}_${{ matrix.config.arch }}
           path: ${{ env.DIST_DIR }}/notarize_temp
 
       - name: Extract macOS binary
@@ -147,19 +212,19 @@ jobs:
         working-directory: ${{ env.DIST_DIR }}/notarize_temp
         run: |
           chmod +x qdl
-          tar -czvf ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_macOS_64bit.tar.gz qdl
-          mv ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_macOS_64bit.tar.gz ../
+          tar -czvf ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz qdl
+          mv ${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz ../
 
       - name: Upload notarized macOS artifact
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}_macOS_64bit 
-          path: ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_${{ github.ref_name }}_macOS_64bit.tar.gz
+          name: ${{ env.ARTIFACT_NAME }}_${{ matrix.config.os }}_${{ matrix.config.arch }}
+          path: ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_${{ github.ref_name }}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
           overwrite: true # Important: replace the original macOS artifact
 
   create-release:
-    needs: [build, sign-and-notarize-macos]
+    needs: [build, sign-and-notarize-macos, build-macos-arm64]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/patches/build_static.patch
+++ b/patches/build_static.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index 203cb04..4482eb8 100644
+index a8fb0da..39c9cc5 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -3,7 +3,7 @@ RAMDUMP := qdl-ramdump
@@ -8,6 +8,6 @@ index 203cb04..4482eb8 100644
  CFLAGS += -O2 -Wall -g `pkg-config --cflags libxml-2.0 libusb-1.0`
 -LDFLAGS += `pkg-config --libs libxml-2.0 libusb-1.0`
 +LDFLAGS += `pkg-config --libs libxml-2.0 libusb-1.0 --static`
- prefix := /usr/local
- 
- QDL_SRCS := firehose.c io.c qdl.c sahara.c util.c patch.c program.c read.c sim.c ufs.c usb.c ux.c oscompat.c
+ ifeq ($(OS),Windows_NT)
+ LDFLAGS += -lws2_32
+ endif


### PR DESCRIPTION
closes https://github.com/arduino/qdl-packing/issues/4

Updating the `arduino/crossbuild` container was too complicated; for the scope of this repo, it is ok to just use GitHub macOS runner.