### PR TITLE
chore: publish tag with release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,11 @@ jobs:
           path: ${{ env.DIST_DIR }}
           merge-multiple: true 
 
-      - name: Tag release to bind tag and commit
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create a tag for the release
         env:
           TAG: ${{ env.REPO_REF }}-${{ github.run_number }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,6 @@ env:
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - '*'
 
 jobs:
   build:
@@ -19,7 +16,7 @@ jobs:
     runs-on:
       ubuntu-latest
     permissions:
-      contents: read 
+      contents: read
     strategy:
       matrix:
         config:
@@ -241,6 +238,15 @@ jobs:
           pattern: ${{ env.ARTIFACT_NAME }}*
           path: ${{ env.DIST_DIR }}
           merge-multiple: true 
+
+      - name: Tag release to bind tag and commit
+        env:
+          TAG: ${{ env.REPO_REF }}-${{ github.run_number }}
+        run: |
+          git config --global user.email "arduinobot@arduino.cc"
+          git config --global user.name "ArduinoBot"
+          git tag ${{ env.TAG }} -m "${{ env.TAG }}"
+          git push origin ${{ env.TAG }}
 
       - name: Create Github Release and upload artifacts
         uses: ncipollo/release-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,6 +232,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
@@ -239,10 +244,6 @@ jobs:
           path: ${{ env.DIST_DIR }}
           merge-multiple: true 
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Create a tag for the release
         env:
           TAG: ${{ env.REPO_REF }}-${{ github.run_number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,4 +257,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
+          prerelease: true
           artifacts: "${{ env.DIST_DIR }}/*"
+          tag: ${{ env.REPO_REF }}-${{ github.run_number }}
+


### PR DESCRIPTION
Update release CI. Now the release will be manually triggered, and the tagged version will include the original qdl version.