### PR TITLE
chore: update qdl to v2.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 env:
   PROJECT_NAME: qdl
   REPO_NAME: linux-msm/qdl
-  REPO_REF: v2.4
+  REPO_REF: v2.5
   DIST_DIR: dist
   ARTIFACT_NAME: dist
 

--- a/patches/build_static.patch
+++ b/patches/build_static.patch
@@ -1,13 +1,13 @@
 diff --git a/Makefile b/Makefile
-index a8fb0da..39c9cc5 100644
+index 0256010..7dcbd90 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -3,7 +3,7 @@ RAMDUMP := qdl-ramdump
- VERSION := $(or $(VERSION), $(shell git describe --dirty --always --tags 2>/dev/null), "unknown-version")
- 
- CFLAGS += -O2 -Wall -g `pkg-config --cflags libxml-2.0 libusb-1.0`
--LDFLAGS += `pkg-config --libs libxml-2.0 libusb-1.0`
-+LDFLAGS += `pkg-config --libs libxml-2.0 libusb-1.0 --static`
+@@ -4,7 +4,7 @@ VERSION := $(or $(VERSION), $(shell git describe --dirty --always --tags 2>/dev/
+
+ PKG_CONFIG ?= pkg-config
+ CFLAGS += -O2 -Wall -g `$(PKG_CONFIG) --cflags libxml-2.0 libusb-1.0`
+-LDFLAGS += `$(PKG_CONFIG) --libs libxml-2.0 libusb-1.0`
++LDFLAGS += `$(PKG_CONFIG) --libs libxml-2.0 libusb-1.0 --static`
  ifeq ($(OS),Windows_NT)
  LDFLAGS += -lws2_32
  endif


### PR DESCRIPTION
Build qdl 2.5 https://github.com/linux-msm/qdl/releases/tag/v2.5

This PR updates the Makefile, so that the LDFLAGS have also `--static`, to make a static build of the tool.